### PR TITLE
fix: setWindowState when target_space is empty

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,3 @@
-# Default temp files
-.DS_*
-*.log
-logs
-**/*.backup.*
-*.bak
-
 # Folder `downloads`
 /downloads
 
@@ -49,12 +42,3 @@ luac.out
 *.x86_64
 *.hex
 
-### VisualStudioCode ###
-.vscode/*
-!.vscode/settings.json
-!.vscode/tasks.json
-!.vscode/launch.json
-!.vscode/extensions.json
-!.vscode/*.code-snippets
-.history
-.ionide

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
+# Default temp files
+.DS_*
+*.log
+logs
+**/*.backup.*
+*.bak
+
 # Folder `downloads`
 /downloads
 
@@ -42,3 +49,12 @@ luac.out
 *.x86_64
 *.hex
 
+### VisualStudioCode ###
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+!.vscode/*.code-snippets
+.history
+.ionide

--- a/restore_spaces/rs/plumbing.lua
+++ b/restore_spaces/rs/plumbing.lua
@@ -210,6 +210,8 @@ return function(rs,hs)
                 window:moveToScreen(target_screen)
                 window:focus()
             end
+        else
+            --mod.issueVerbose("message with the window ID...", mod.verbose)
         end
 
         rs.setFrameState(window, frame_state, fullscreen_state)

--- a/restore_spaces/rs/plumbing.lua
+++ b/restore_spaces/rs/plumbing.lua
@@ -195,19 +195,21 @@ return function(rs,hs)
         else
             target_space = space
         end
-        --target_space = tonumber(target_space)
+        if target_space then
+            --target_space = tonumber(target_space)
 
-        if rs.spaces_fixed_after_macOS14_5 then
-            hs.spaces.moveWindowToSpace(window, target_space)
-        else
-            -- solution by `cunha`
-            -- (see: https://github.com/Hammerspoon/hammerspoon/pull/3638#issuecomment-2252826567)
-            local target_screen, _ = hs.spaces.spaceDisplay(target_space)
-            hs.spaces.moveWindowToSpace(window, target_space)
-            window:focus()
-            rs.delayExecution(0.4)
-            window:moveToScreen(target_screen)
-            window:focus()
+            if rs.spaces_fixed_after_macOS14_5 then
+                hs.spaces.moveWindowToSpace(window, target_space)
+            else
+                -- solution by `cunha`
+                -- (see: https://github.com/Hammerspoon/hammerspoon/pull/3638#issuecomment-2252826567)
+                local target_screen, _ = hs.spaces.spaceDisplay(target_space)
+                hs.spaces.moveWindowToSpace(window, target_space)
+                window:focus()
+                rs.delayExecution(0.4)
+                window:moveToScreen(target_screen)
+                window:focus()
+            end
         end
 
         rs.setFrameState(window, frame_state, fullscreen_state)

--- a/restore_spaces/rs/plumbing.lua
+++ b/restore_spaces/rs/plumbing.lua
@@ -211,7 +211,7 @@ return function(rs,hs)
                 window:focus()
             end
         else
-            --mod.issueVerbose("message with the window ID...", mod.verbose)
+            rs.issueVerbose("target space undefined; unable to set window " .. window:id(), rs.verbose)
         end
 
         rs.setFrameState(window, frame_state, fullscreen_state)

--- a/restore_spaces/rs/porcelain.lua
+++ b/restore_spaces/rs/porcelain.lua
@@ -106,7 +106,7 @@ return function(rs,hs)
 
         rs.data_wins = rs.processDataInFile("read","windows")
         if not rs.data_wins[env_name] then
-            error("State for environment has never been saved!")
+            error("State for environment [" .. env_name .. "] has never been saved!")
         end
         local env_state = rs.data_wins[env_name]
 


### PR DESCRIPTION
- Fix crash when target space is empty during setting of window state
- also adding default excludes for vscode editor in .gitignore
